### PR TITLE
Move unresponsive server to the bottom of the list

### DIFF
--- a/public-servers.hjson
+++ b/public-servers.hjson
@@ -1,10 +1,10 @@
 // Public CLaJ node list
 "Chaotic Neutral FR": "n4.xpdustry.com:50000"
+"Eradication India": "in3.eradication.fun:8025"
 "Eradication USA": "us1.eradication.fun:8025"
 "Eradication UK": "uk1.eradication.fun:8025"
+"Eradication RU": "ru1.eradication.fun:8025"
 "MDF Alps": "2.7.107.21:50000"
 "Mindustry France™ Official": "claj.jojofr.dev:34650"
 "German bunny DE": "claj.l4p1n.ch:50000"
 "Mindustry.ltd China": "p2.mindustry.ltd:35850"
-"Eradication India": "in3.eradication.fun:8025"
-"Eradication RU": "ru1.eradication.fun:8025"

--- a/public-servers.hjson
+++ b/public-servers.hjson
@@ -1,10 +1,10 @@
 // Public CLaJ node list
 "Chaotic Neutral FR": "n4.xpdustry.com:50000"
-"Mindustry.ltd China": "p2.mindustry.ltd:35850"
-"Eradication India": "in3.eradication.fun:8025"
 "Eradication USA": "us1.eradication.fun:8025"
 "Eradication UK": "uk1.eradication.fun:8025"
-"Eradication RU": "ru1.eradication.fun:8025"
 "MDF Alps": "2.7.107.21:50000"
 "Mindustry France™ Official": "claj.jojofr.dev:34650"
 "German bunny DE": "claj.l4p1n.ch:50000"
+"Mindustry.ltd China": "p2.mindustry.ltd:35850"
+"Eradication India": "in3.eradication.fun:8025"
+"Eradication RU": "ru1.eradication.fun:8025"


### PR DESCRIPTION
Those servers have been unresponsive for a while now and the current version of CLaJ client is severely limited by having one pinger and a huge timeout of 5000ms. It adds an overhead of 15 seconds to load the bottom list server which have a big impact on the brand new server.

You should consider removing them if the unresponsiveness continues.

UK Eradication is also not responding but it is quite recent so it was not moved.