### PR TITLE
Mindustry v8 compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
@@ -28,25 +28,24 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build Client Artifacts
-        run: gradle client:build client:buildV8
-
-      - name: Build Server Artifact
-        run: gradle server:build
+      - name: Build Artifacts
+        run: gradle build
  
       - name: Upload Client Artifacts to Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "${{ github.event.repository.name }}-client"
           path: client/build/libs/${{ github.event.repository.name }}-client*.jar
           if-no-files-found: error
+          archive: false
 
       - name: Upload Server Artifact to Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "${{ github.event.repository.name }}-server"
           path: server/build/libs/${{ github.event.repository.name }}-server.jar
           if-no-files-found: error
+          archive: false
 
       - name: Publish Artifacts
         if: ${{ github.event_name == 'release' }}

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/eclipse,gradle,java
 
+### Custom ###
+.idea/

--- a/api/src/com/xpdustry/claj/api/ClajPingerManager.java
+++ b/api/src/com/xpdustry/claj/api/ClajPingerManager.java
@@ -222,7 +222,7 @@ public class ClajPingerManager {
     });
   }
 
-  /** @apiNote async operation but blocking new tasks if a ping is already in progress */
+  /** Note: async operation but blocking new tasks if a ping is already in progress */
   public void pingHost(String ip, int port, Cons<ServerState> success, Cons<Exception> failed) {
     submit((pinger, finished) -> {
       pinger.pingHost(ip, port, i -> {

--- a/api/src/com/xpdustry/claj/api/net/ProxyClient.java
+++ b/api/src/com/xpdustry/claj/api/net/ProxyClient.java
@@ -39,7 +39,7 @@ import com.xpdustry.claj.common.util.Structs;
  * - Packet reception must be done manually. <br>
  * - Notifying methods must be called ({@link #conConnected}, {@link #conDisconnected}, {@link #conReceived} and
  * {@link #conIdle}). <br>
- * - Packet making methods must be defined ({@link #makeWrapPacket} and {@link #makeClosePacket}).
+ * - Packet making methods must be defined ({@link #makeConWrapPacket} and {@link #makeConClosePacket(int, DcReason)}).
  */
 public abstract class ProxyClient extends Client {
   public static int defaultTimeout = 5000; //ms

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 import com.xpdustry.toxopid.spec.ModMetadata
+import com.xpdustry.toxopid.task.MindustryExec
+import com.xpdustry.toxopid.extension.TaskExtensions
 import com.xpdustry.toxopid.spec.ModPlatform
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.util.regex.Pattern
 
 plugins {
   id "java"
-  id "com.xpdustry.toxopid" version "4.1.2"
+  id "com.xpdustry.toxopid" version "4.2.0"
   id "net.kyori.indra.publishing" version "3.1.3"
 }
 
@@ -54,6 +53,11 @@ allprojects {
   dependencies {
     // Temporary: added record desugarization. See: https://github.com/xpdustry/jabel
     annotationProcessor rootProject.files("libs/jabel.jar") //"com.github.Anuken:jabel:0.9.0"
+  }
+
+  java {
+    withJavadocJar()
+    withSourcesJar()
   }
 }
 
@@ -105,47 +109,24 @@ project(":client") {
       }
     }
   }
-	
+
   // Includes android dex
   build.dependsOn mergeJar
 
-  // Make compatible with Mindustry v8. Will just replace 'minGameVersion' in mod.hjson.
-  task buildV8(type: Jar, dependsOn: [mergeJar]) {
-    def modHjsonText = rootProject.file("mod.hjson").getText("UTF-8")
-    def mv8Match = (modHjsonText =~ /(?m)^\s*minGameVersionV8\s*:\s*"([^"]+)"/)
-    def v8MinGameVersion = mv8Match.find() ? mv8Match.group(1) : null
-    if (v8MinGameVersion == null) throw new Exception("mod.hjson is missing 'minGameVersionV8'.")
+  tasks.runMindustryDesktop {
+    mods.from(mergeJar)
+  }
 
-    archiveFileName = "${metadata.name}-${project.name}-v8.jar"
-
-    // Start from the jar produced by mergeJar, but drop its mod.hjson entry.
-    from({ zipTree(mergeJar.archiveFile.get().asFile) }, { exclude "mod.hjson" })
-    
-    // Add a filtered mod.hjson at the root of the jar.
-    from(rootDir) {
-      include "mod.hjson"
-      //includeEmptyDirs = false
-      filter {
-        if (it == null) return null
-        if (it ==~ /^\s*minGameVersionV8\s*:.*$/) return null
-        if (it ==~ /^\s*minGameVersion\s*:.*$/) return "minGameVersion: \"${v8MinGameVersion}\""
-        return it
-      }
-    }
-
-    doLast {
-      copy {
-        from buildV8
-        into rootDir
-      }
-    }
+  tasks.register("runMindustryDesktop2", MindustryExec) {
+    mods.from(mergeJar)
+    TaskExtensions.configureDesktop(it)
   }
 }
 
 project(":server") {
   ext.mainClassName = "com.xpdustry.claj.server.Main"
   toxopid.platforms = [ModPlatform.SERVER]
-  toxopid.compileVersion = "v154"
+  toxopid.compileVersion = "v157"
 
   dependencies {
     implementation project(":common")
@@ -185,9 +166,7 @@ project(":server") {
   }
 }
 
-build.dependsOn "client:buildV8"
-task buildAll(type: Jar, dependsOn: ["client:build", "client:buildV8", "server:build"]) {}
-
+task buildAll(type: Jar, dependsOn: ["client:build", "server:build"]) {}
 
 // Publishing
 signing {
@@ -201,7 +180,7 @@ indra {
     target(8)
     minimumToolchain(8)
   }
-    
+
   gpl3OnlyLicense()
   publishReleasesTo("xpdustry", "https://maven.xpdustry.com/releases")
 
@@ -213,10 +192,6 @@ indra {
   }
 
   configurePublications {
-    from components.java
-    artifact sourcesJar
-    artifact javadocJar
-  
     pom {
       organization {
         name = "Xpdustry"
@@ -233,14 +208,4 @@ indra {
       }
     }
   }
-}
-
-// I want these to only be included when publishing, not all the time...
-task javadocJar(type: Jar, dependsOn: 'javadoc') {
-  from javadoc.destinationDir
-  archiveClassifier = 'javadoc'
-}
-task sourcesJar(type: Jar, dependsOn: 'classes') {
-  from sourceSets.main.allSource
-  archiveClassifier = 'sources'
 }

--- a/client/src/com/xpdustry/claj/client/dialogs/CreateRoomDialog.java
+++ b/client/src/com/xpdustry/claj/client/dialogs/CreateRoomDialog.java
@@ -47,8 +47,9 @@ import com.xpdustry.claj.common.status.CloseReason;
 
 
 public class CreateRoomDialog extends BaseDialog {
-  /** {@link Styles#togglet} but {@link TextButtonStyle#checked} is {@link Tex#buttonOver}
-   *  instead of {@link Tex#buttonDown}. */
+  /** {@link Styles#togglet} but {@link TextButtonStyle#checked} is "{Tex#buttonOver}"
+   *  instead of "{Tex#buttonDown}". */
+  // TODO Fix links to Tex#buttonDown and Tex#buttonOver
   public static final TextButtonStyle fixedToglet = new TextButtonStyle(Styles.togglet);
   static { fixedToglet.checked = fixedToglet.over; }
 

--- a/common/src/com/xpdustry/claj/common/net/stream/StreamBuilder.java
+++ b/common/src/com/xpdustry/claj/common/net/stream/StreamBuilder.java
@@ -30,8 +30,8 @@ import arc.util.io.ReusableByteOutStream;
 import com.xpdustry.claj.common.ClajNet;
 import com.xpdustry.claj.common.packets.Packet;
 
-
-/** {@link mindustry.net.Streamable.StreamBuilder}. */
+// TODO Fix link
+/** {mindustry.net.Streamable.StreamBuilder}. */
 public class StreamBuilder {
   public final int id;
   public final byte type;

--- a/common/src/com/xpdustry/claj/common/net/stream/StreamChunk.java
+++ b/common/src/com/xpdustry/claj/common/net/stream/StreamChunk.java
@@ -22,8 +22,8 @@ package com.xpdustry.claj.common.net.stream;
 import arc.util.io.ByteBufferInput;
 import arc.util.io.ByteBufferOutput;
 
-
-/** {@link mindustry.net.Packets.StreamChunk}. */
+// TODO Fix link
+/** {mindustry.net.Packets.StreamChunk}. */
 public class StreamChunk implements StreamPacket {
   public int id;
   public boolean last;

--- a/common/src/com/xpdustry/claj/common/net/stream/StreamHead.java
+++ b/common/src/com/xpdustry/claj/common/net/stream/StreamHead.java
@@ -22,8 +22,8 @@ package com.xpdustry.claj.common.net.stream;
 import arc.util.io.ByteBufferInput;
 import arc.util.io.ByteBufferOutput;
 
-
-/** {@link mindustry.net.Packets.StreamBegin}. */
+// TODO Fix link
+/** {mindustry.net.Packets.StreamBegin}. */
 public class StreamHead implements StreamPacket {
   private static int lastid;
 

--- a/common/src/com/xpdustry/claj/common/net/stream/StreamSender.java
+++ b/common/src/com/xpdustry/claj/common/net/stream/StreamSender.java
@@ -29,9 +29,9 @@ import com.xpdustry.claj.common.ClajNet;
 import com.xpdustry.claj.common.packets.Packet;
 import com.xpdustry.claj.common.util.ByteArrayBufferOutput;
 
-
+// TODO Fix link
 /**
- * {@link mindustry.net.ArcNetProvider.ArcConnection#sendStream(mindustry.net.Streamable)}.
+ * {mindustry.net.ArcNetProvider.ArcConnection#sendStream(mindustry.net.Streamable)}.
  * <p>
  * Note: {@link StreamHead} and {@link StreamChunk} must be registered in {@link ClajNet}.
  */

--- a/common/src/com/xpdustry/claj/common/packets/RoomListPacket.java
+++ b/common/src/com/xpdustry/claj/common/packets/RoomListPacket.java
@@ -26,8 +26,8 @@ import arc.struct.ObjectSet;
 import arc.util.io.ByteBufferInput;
 import arc.util.io.ByteBufferOutput;
 
-
-/** Can be a huge packet, should be sent with {@link StreamSender} instead. */
+// TODO Fix link
+/** Can be a huge packet, should be sent with {StreamSender} instead. */
 public class RoomListPacket extends DelayedPacket {
   public final LongMap<ByteBuffer> states = new LongMap<>();
   public final ObjectSet<Long> protectedRooms = new ObjectSet<>(32);

--- a/common/src/com/xpdustry/claj/common/util/Strings.java
+++ b/common/src/com/xpdustry/claj/common/util/Strings.java
@@ -213,8 +213,8 @@ public class Strings extends arc.util.Strings {
    * Compare if the {@code newVersion} is greater than the {@code currentVersion}, e.g. "v146" > "124.1". <br>
    * {@code maxDepth} limits the number of comparisons of version segments, allowing sub-versions to be ignored.
    * (default is 0)
-   *
-   * @apiNote can handle dots and dashes in the version and makes very fast comparison. <br>
+   * <p>
+   * Note: can handle dots and dashes in the version and makes very fast comparison. <br>
    *          Also ignores non-int parts. (e.g. {@code "v1.2-rc36"}, the {@code "rc36"} part will be ignored)
    */
   public static boolean isVersionAtLeast(String currentVersion, String newVersion, int maxDepth) {

--- a/mod.hjson
+++ b/mod.hjson
@@ -10,9 +10,8 @@ CLaJ (Copy Link and Join) allows you to play with your friends, just by creating
 
 [lightgray]Note: To install the mod for Mindustry v8, click 'View Releases' instead of 'Install' and install the latest version named 'CLaJ for Mindustry V8'.[]
 '''
-version: "2.4"
-minGameVersion: "146"
-minGameVersionV8: "154" // Will be renamed to 'minGameVersion' if using the 'client:buildV8' gradle task
+version: "2.5"
+minGameVersion: "157"
 java: true
 hidden: true
 repo: xpdustry/claj

--- a/mod.hjson
+++ b/mod.hjson
@@ -10,7 +10,7 @@ CLaJ (Copy Link and Join) allows you to play with your friends, just by creating
 
 [lightgray]Note: To install the mod for Mindustry v8, click 'View Releases' instead of 'Install' and install the latest version named 'CLaJ for Mindustry V8'.[]
 '''
-version: "2.5"
+version: "2.4"
 minGameVersion: "157"
 java: true
 hidden: true

--- a/server/src/com/xpdustry/claj/server/ClajRoom.java
+++ b/server/src/com/xpdustry/claj/server/ClajRoom.java
@@ -39,9 +39,10 @@ public class ClajRoom implements NetListener {
 
   /** The room id. */
   public final long id;
+  // TODO Fix link
   /**
    * The room id encoded in an url-safe base64 string.
-   * @see com.xpdustry.claj.api.ClajLink
+   * "@see com.xpdustry.claj.api.ClajLink"
    */
   public final String sid;
   /** The host connection of this room. */

--- a/server/src/com/xpdustry/claj/server/plugin/Plugins.java
+++ b/server/src/com/xpdustry/claj/server/plugin/Plugins.java
@@ -39,8 +39,8 @@ import arc.util.serialization.Jval;
 import com.xpdustry.claj.server.util.JarLoader;
 import com.xpdustry.claj.server.util.JsonSettings;
 
-
-/** Simplified {@link mindustry.mod.Mods} that only handles plugins. */
+// TODO Fix link
+/** Simplified {mindustry.mod.Mods} that only handles plugins. */
 public class Plugins implements ApplicationListener {
   private static final String[] metaFiles = {"plugin.json", "plugin.hjson"};
 

--- a/server/src/com/xpdustry/claj/server/util/JsonSettings.java
+++ b/server/src/com/xpdustry/claj/server/util/JsonSettings.java
@@ -338,7 +338,7 @@ public class JsonSettings implements Autosaver.Saveable {
     put(name, elementType, null, value);
   }
 
-  /** @apiNote {@code keyType} is not supported and ignored. object keys are converted using {@link String#valueOf(Object)} */
+  /** Note: {@code keyType} is not supported and ignored. object keys are converted using {@link String#valueOf(Object)} */
   public synchronized <K, E> void put(String name, Class<E> elementType, Class<K> keyType, Object value) {
     // Store primitive, null and JsonValue values directly instead of converting it to JsonValue
     if (value == null || isKnownType(value.getClass())) {


### PR DESCRIPTION
- Bumped Mindustry version to v8.
- Removed v7 build task (if someone needs to run an older claj server, he should use an older claj release).
- Tried to fix publishing because only the root project "claj" is published and not the components, did not really succeeded.
- Fixed javadoc because it was only applied to the root project and not the subprojects.
- Updated CI to use the latest actions versions.
- Fixed runMindustryDesktop task and added an additional one for local testing.